### PR TITLE
favorite support for album and artist

### DIFF
--- a/qml/components/FavoritesManager.qml
+++ b/qml/components/FavoritesManager.qml
@@ -1,0 +1,138 @@
+import QtQuick 2.0
+import io.thp.pyotherside 1.5
+
+
+Item {
+    id: root
+
+    Timer {
+        id: updateTimer
+        interval: 1000  // 100ms Verzögerung
+        repeat: false
+        onTriggered: {
+
+                //playlistStorage.loadCurrentPlaylistState()
+        }
+    }
+    property var favoritesCache: ({})  // Object to store id -> boolean mappings
+
+    signal updateFavorite(var id, var status)  // signal that an fav status was updated
+
+    Python {
+        id: favoritesPython
+
+
+        property bool initialised : false
+
+        Component.onCompleted: {
+
+            addImportPath(Qt.resolvedUrl('.'))
+        
+            // Response Loading finished
+            setHandler('updateFavorite', function(id,status) {
+                addFavoriteInfo(id, status)
+                root.updateFavorite(id, status)
+            })
+
+            initialised = true;
+        }
+
+        // Python-Funktionen
+        // i think this one is obsolete, just return from cache in qml
+        function isFavorite(id) {
+            //if(initialised)  call('playlistmanager.PL.AppendTrack', [id], {})
+            // should throw a signal with the result
+        }
+
+        function setArtistFavoriteInfo(id, status) {
+            console.log("setArtistFavoriteInfo", id, status)
+            if(initialised)  call('tidal.Tidaler.setArtistFavInfo', [id, status], {})
+        }
+
+        function setAlbumFavoriteInfo(id, status) {
+           if(initialised)  call('tidal.Tidaler.setAlbumFavInfo', [id, status], {})
+        }
+
+        function setTrackFavoriteInfo(id, status) {
+           if(initialised)  call('tidal.Tidaler.setTrackFavInfo', [id, status], {})
+        }
+
+        function setPlaylistFavoriteInfo(id, status) {
+           if(initialised)  call('tidal.Tidaler.setPlaylistFavInfo', [id, status], {})
+        }
+
+    }
+
+
+    // public function to check if item is favorite
+    function isFavorite(id) {
+        console.log("isFavorite check for:", id)
+        if (id in favoritesCache) {
+            console.log("Cache hit for:", id, "Status:", favoritesCache[id])
+            return favoritesCache[id]
+        }
+        // Not in cache, need to load from Tidal
+        // I doubt i need this, as all changes in the session
+        // can be managed by favoritesManager
+        // favoritesPython.isFavorite(id)
+        return false  // Return false while loading
+    }
+
+    function setArtistFavoriteInfo(id, status) {
+        console.log("setArtistFavoriteInfo", id, status)
+        favoritesPython.setArtistFavoriteInfo(id, status)
+    }
+
+    function setAlbumFavoriteInfo(id, status) {
+        console.log("setAlbumFavoriteInfo", id, status)
+        favoritesPython.setAlbumFavoriteInfo(id, status)
+    }
+
+    function setTrackFavoriteInfo(id, status) {
+        console.log("setTrackFavoriteInfo", id, status)
+        favoritesPython.setTrackFavoriteInfo(id, status)
+    }
+
+    function setPlaylistFavoriteInfo(id, status) {
+        console.log("setPlaylistFavoriteInfo", id, status)
+        // this should happen only on success !!
+        // favoritesCache[id] = status
+        favoritesPython.setPlaylistFavoriteInfo(id, status)
+    }
+
+    // internal function to add favorite
+    function addFavorite(id) {
+        favoritesCache[id] = true
+    }
+
+    // internal function to add favorite
+    function addFavoriteInfo(id, status) {
+        favoritesCache[id] = status
+    }
+
+    Connections {
+        target: tidalApi
+        onFavArtists: {
+            if (artist_info == undefined) {
+                 console.error("artist_info is undefined. skip append to model")
+                 return;
+            }
+            addFavorite(artist_info.artistid)
+        }
+        onFavAlbums: {
+            if (album_info == undefined) {
+                 console.error("album_info is undefined. skip append to model")
+                 return;
+            }            
+            addFavorite(album_info.albumid)
+        }
+        onFavTracks: {
+            if (track_info == undefined) {
+                 console.error("track_info is undefined. skip append to model")
+                 return;
+            }            
+            addFavorite(track_info.trackid)
+        }
+    }
+
+}

--- a/qml/components/PlaylistManager.qml
+++ b/qml/components/PlaylistManager.qml
@@ -256,11 +256,10 @@ Item {
         return id
     }
 
-    // to minimze sideeffects, clear remains default
     function playAlbum(id, startPlay) {
         var shouldPlay = startPlay === undefined ? true : startPlay
         console.log("playalbum", id, startPlay)
-        tidalApi.playAlbumTracks(id,shouldPlay) //todo: pass argument or second method?
+        tidalApi.playAlbumTracks(id,shouldPlay)
         currentTrackIndex()
     }
 

--- a/qml/components/TidalCache.qml
+++ b/qml/components/TidalCache.qml
@@ -194,7 +194,7 @@ id: root
                 year : result.year,
                 timestamp: Date.now()
             }
-
+            console.log("album not in cache, adding to cache ... (i think this causes the nulls, as it should be synchr.) ", result)
             saveAlbumToCache(albumData)
             return albumData
         }

--- a/qml/harbour-tidalplayer.qml
+++ b/qml/harbour-tidalplayer.qml
@@ -121,6 +121,10 @@ ApplicationWindow
 
     }
 
+    FavoritesManager {
+        id: favManager
+    }
+
     TidalCache
     {
         id: cacheManager

--- a/qml/pages/AlbumPage.qml
+++ b/qml/pages/AlbumPage.qml
@@ -10,6 +10,7 @@ Page {
     property int albumId: -1
     property var albumData: null
     property bool isHeaderCollapsed: false
+    property bool isFav: false
     //property alias model: listModel
 
     allowedOrientations: Orientation.All
@@ -108,6 +109,23 @@ Page {
                             color: Theme.rgba(Theme.highlightBackgroundColor, 0.1)
                             anchors.fill: parent
                             visible: coverImage.status !== Image.Ready
+                        }
+
+                        IconButton {
+                            id: favButton
+                            width: Theme.iconSizeMedium
+                            height: Theme.iconSizeMedium
+                            anchors {
+                                top: coverImage.top
+                                right: coverImage.right
+                                margins: Theme.paddingSmall
+                            }
+                            icon.source: "image://theme/icon-s-favorite"
+                            highlighted: isFav
+                            onClicked: {
+                               favManager.setAlbumFavoriteInfo(albumId,!isFav)
+                            }
+                            z:1 // tobe on top of the image
                         }
                     }
 
@@ -266,6 +284,17 @@ Page {
             if (!albumData) {
                 console.log("Album nicht im Cache gefunden:", albumId)
             }
+
+            isFav = favManager.isFavorite(albumId)
+        }
+    }
+
+    Connections {
+        target: favManager
+
+        onUpdateFavorite: {
+            if (id === albumId)
+                isFav = status
         }
     }
 }

--- a/qml/pages/ArtistPage.qml
+++ b/qml/pages/ArtistPage.qml
@@ -9,6 +9,7 @@ Page {
     property int artistId: -1
     property var artistData: null
     property bool isHeaderCollapsed: false
+    property bool isFav: false
 
     function processWimpLinks(text) {
         if (!text) return ""
@@ -102,6 +103,23 @@ Page {
                             color: Theme.rgba(Theme.highlightBackgroundColor, 0.1)
                             anchors.fill: parent
                             visible: coverImage.status !== Image.Ready
+                        }
+
+                        IconButton {
+                            id: favButton
+                            width: Theme.iconSizeMedium
+                            height: Theme.iconSizeMedium
+                            anchors {
+                                top: coverImage.top
+                                right: coverImage.right
+                                margins: Theme.paddingSmall
+                            }
+                            icon.source: "image://theme/icon-s-favorite"
+                            highlighted: isFav
+                            onClicked: {
+                               favManager.setArtistFavoriteInfo(artistId,!isFav)
+                            }
+                            z:1 // tobe on top of the image
                         }
                     }
 
@@ -296,9 +314,21 @@ Page {
                 var processedBio = processWimpLinks(artistData.bio)
                 bioText.text = processedBio
             }
+
+            isFav = favManager.isFavorite(artistId)
+
             tidalApi.getAlbumsofArtist(artistData.artistid)
             tidalApi.getTopTracksofArtist(artistData.artistid)
             tidalApi.getSimiliarArtist(artistData.artistid)
+        }
+    }
+
+    Connections {
+        target: favManager
+
+        onUpdateFavorite: {
+            if (id === artistId)
+                isFav = status
         }
     }
 


### PR DESCRIPTION
the icon is too small and needs some background on some colours
i did implement it for tracks and playlist too, but for playlist there is no view (yet?)
pull request contains also the .py part for start playing album playlist.
i have seem to missed that in the last pull

favorites are stored only in ram
i use your fav load on start to populate the list

regarding tidalapi, i did include that into tidalapi.py
first i wanted to create an own .py, but honestly i am not sure how to interlink that with tidaler.session etc.
if you think it is cleaner to move those methods into an own file and know how to do it (:)) your welcome
