### PR TITLE
Player previous button behaviour changes

### DIFF
--- a/qml/components/PlaylistManager.qml
+++ b/qml/components/PlaylistManager.qml
@@ -345,7 +345,7 @@ Item {
         // first press of the previous track button should skip to
         // the beginning of the current track
         // TODO: Add a setting to enable/disable this feature?
-        if(!skipTrack)
+        if(!skipTrack || !canPrev)
         {
             restartTrack(currentId)
             skipTrack = true

--- a/qml/components/PlaylistManager.qml
+++ b/qml/components/PlaylistManager.qml
@@ -15,6 +15,15 @@ Item {
         }
     }
 
+    Timer {
+        id: skipTrackGracePeriod
+        interval: 5000
+        repeat: false
+        onTriggered: {
+            skipTrack = false
+        }
+    }
+
     //property var currentPlaylist: []
     property int currentIndex: -1
     property bool canNext: size > 0 && currentIndex < size - 1
@@ -22,6 +31,7 @@ Item {
     property int size: 0 //currentPlaylist.length
     property int current_track: -1
     property int tidalId : 0
+    property bool skipTrack : false
 
     signal currentTrackChanged(var track)
     signal playlistChanged()
@@ -326,15 +336,31 @@ Item {
 
     function restartTrack(id) {
         playlistPython.restartTrack()
+        // for whatever reason we need to seek(0) here
+        mediaController.seek(0)
         currentTrackIndex()
     }
 
     function previousTrackClicked() {
+        // first press of the previous track button should skip to
+        // the beginning of the current track
+        // TODO: Add a setting to enable/disable this feature?
+        if(!skipTrack)
+        {
+            restartTrack(currentId)
+            skipTrack = true
+            // if this is not what we want, give a 5s grace period
+            // to click the previous track again and actually skip
+            // to the previous song
+            skipTrackGracePeriod.restart()
+            return
+        }
+
         playlistPython.canNext = false
         mediaController.blockAutoNext = true
         playlistPython.previousTrack()
         currentTrackIndex()
-         if (playlistStorage.playlistTitle) {
+        if (playlistStorage.playlistTitle) {
             playlistStorage.updatePosition(playlistStorage.playlistTitle, currentIndex);
         }
     }

--- a/qml/pages/widgets/MiniPlayer.qml
+++ b/qml/pages/widgets/MiniPlayer.qml
@@ -114,7 +114,6 @@ DockedPanel {
                     id: prevButton
                     icon.source: "image://theme/icon-m-previous"
                     // icons move around horizontally when using visible
-                    enabled: playlistManager.canPrev
                     onClicked:
                     {
                         console.log("prev button pressed")
@@ -267,7 +266,6 @@ DockedPanel {
          {
             mediaTitle.text = trackinfo.track_num + " - " + trackinfo.title + " - " + trackinfo.album + " - " + trackinfo.artist
             bgImage.source = trackinfo.image
-            prevButton.enabled = playlistManager.canPrev
             nextButton.enabled = playlistManager.canNext
             progressSlider.visible = true
             //mprisPlayer.updateTrack(title, artist, album)


### PR DESCRIPTION
Hi!

These changes don't immediately skip to the previous song when the button is clicked, and skips to the beginning of the song instead. If the button is clicked again within 5 seconds, the previous song is played.

This is inline with other music players on different platforms.

Thanks